### PR TITLE
Enhance discover_limelights to optionally return device names and added get_ip_by_name function to Library

### DIFF
--- a/limelightlib-python/limelight.py
+++ b/limelightlib-python/limelight.py
@@ -50,9 +50,28 @@ def listen_for_responses(port,timeout=1):
             pass
     return discovered_devices
 
-def discover_limelights(broadcast_port=5809, listen_port=5809, timeout=2, debug=False):
+def discover_limelights(broadcast_port=5809, listen_port=5809, timeout=2, debug=False, return_names=False):
     broadcast_on_all_interfaces("LLPhoneHome",broadcast_port,debug)
-    return listen_for_responses(listen_port,timeout)
+    ips = listen_for_responses(listen_port, timeout)
+    
+    results = []
+    for ip in ips:
+        name = None
+        if return_names:
+            try:
+                ll = Limelight(ip)
+                name = ll.get_name()
+            except Exception as e:
+                if debug:
+                    print(f"Failed to get name for {ip}: {e}")
+        results.append({"ip": ip, "name": name})
+    return results
+
+def get_ip_by_name(discovered, name):
+    for entry in discovered:
+        if entry["name"] == name:
+            return entry["ip"]
+    return None
 
 class Limelight:
     def __init__(self, address):

--- a/limelightlib-python/limelight.py
+++ b/limelightlib-python/limelight.py
@@ -73,6 +73,12 @@ def get_ip_by_name(discovered, name):
             return entry["ip"]
     return None
 
+def get_name_by_ip(discovered, ip_address):
+    for entry in discovered:
+        if entry["ip"] == ip_address:
+            return entry["name"]
+    return None 
+
 class Limelight:
     def __init__(self, address):
         self.base_url = f"http://{address}:5807"


### PR DESCRIPTION
This change allows users to get a name for the limelights discovered vs just a list of ip's which helps users using multiple cameras.

here is an example snippet of the new behavior of utilizing the discovered limelights function which is different from the example


```
discovered_limelights = limelight.discover_limelights(debug=True, return_names=True)

print("discovered limelights:", discovered_limelights)

limelight_address = discovered_limelights[0]['ip']

limelight_name = discovered_limelights[0]['name']

#alternate method

limelight_name = limelight.get_name_by_ip(discovered_limelights, limelight_address)
```


You now need to specify you are looking for the IP of the limelight of the index of 0. I added another robust method to getting ip's however with the get_ip_by_name function this code snippet now looks like this.


```
discovered_limelights = limelight.discover_limelights(debug=True, return_names=True)

print("discovered limelights:", discovered_limelights)

limelight_address = limelight.get_ip_by_name(discovered_limelights, "limelight")

```

if return_names is false

```
discovered_limelights = limelight.discover_limelights(debug=True, return_names=False)

print("discovered limelights:", discovered_limelights) #this line will only print IP's vs names aswell

limelight_address = discovered_limelights[0]['ip']

limelight_name = discovered_limelights[0]['name']#this line will return none unless you set return names to true

```


This allows users that use multiple limelights to not have to worry about order of discovery or if they disconnect a camera before startup the ip will be found if it's automatic vs static. 

Setting the return_names parameter to false results in identical behavior to the previous release of LimelightLib-Python just you still need to add the ['ip] specification if looking for an ip on discovered limelights.